### PR TITLE
Use setlocal to correctly override filetype

### DIFF
--- a/ftdetect/jsonc.vim
+++ b/ftdetect/jsonc.vim
@@ -1,2 +1,2 @@
-au BufNewFile,BufRead *.cjson setfiletype jsonc
-au BufNewFile,BufRead coc-settings.json setfiletype jsonc
+autocmd BufNewFile,BufRead *.cjson setlocal filetype=jsonc
+autocmd BufNewFile,BufRead coc-settings.json setlocal filetype=jsonc


### PR DESCRIPTION
This is needed to override (neo)vim json filetype detection, without `setlocal` filetype continues as `json`.