### PR TITLE
Use default json indenting

### DIFF
--- a/indent/jsonc.vim
+++ b/indent/jsonc.vim
@@ -1,0 +1,1 @@
+runtime! indent/json.vim


### PR DESCRIPTION
Load the default json indent script for jsonc files