### PR TITLE
Detect vscode configuration files as jsonc

### DIFF
--- a/ftdetect/jsonc.vim
+++ b/ftdetect/jsonc.vim
@@ -9,3 +9,4 @@ autocmd BufNewFile,BufRead .mocharc.json setlocal filetype=jsonc
 autocmd BufNewFile,BufRead coffeelint.json setlocal filetype=jsonc
 autocmd BufNewFile,BufRead tsconfig.json setlocal filetype=jsonc
 autocmd BufNewFile,BufRead jsconfig.json setlocal filetype=jsonc
+autocmd BufNewFile,BufRead */.vscode/*.json setlocal filetype=jsonc


### PR DESCRIPTION
Treat the `.json` files in the `.vscode` folder as `.jsonc` files.

e.g. 

* `launch.json`
* `extensions.json`
* `settings.json`
* `tasks.json`
* ...

The `.vscode` folder does not contain any "non-`.jsonc`" files as far as I know.